### PR TITLE
Tests for UnseenSetDropdown

### DIFF
--- a/src/components/UnseenSetDropdown.vue
+++ b/src/components/UnseenSetDropdown.vue
@@ -9,7 +9,7 @@
         v-for="unseenSetID in unseenSetIDs"
         :key="unseenSetID.menuItemLabel"
         :value="unseenSetID.primitive"
-        :selected="select == null ? '' : select == unseenSetID.primitive"
+        :selected="selected == unseenSetID.primitive"
       >
         {{ unseenSetID.menuItemLabel }}
       </option>
@@ -17,7 +17,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import UnseenSetID from "@/service/unseen-set-id";
 
 export default {
@@ -28,7 +28,7 @@ export default {
   },
   props: {
     disabled: Boolean,
-    select: null,
+    selected: Number,
   },
   emits: ["change"],
 };

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -3,7 +3,7 @@
     <unseen-set-dropdown
       class="m-3"
       :disabled="hasPlayedGame"
-      :select="select"
+      :selected="selected"
       @change="unseenSetChanged"
     />
   </div>
@@ -32,7 +32,7 @@ import UnseenSetID from "@/service/unseen-set-id";
 
 export default {
   data: () => ({
-    select: UnseenSetID.Top999WiktionaryFr.primitive,
+    selected: UnseenSetID.Top999WiktionaryFr.primitive,
   }),
   components: { GradientButton, ScoreBoard, UnseenSetDropdown },
   methods: {
@@ -67,7 +67,7 @@ export default {
     },
     async unseenSetChanged(event) {
       await useGameStore().setUnseenSet(new UnseenSetID(event.target.value));
-      this.select = event.target.value;
+      this.selected = Number(event.target.value);
     },
   },
   computed: {

--- a/src/test/components/UnseenSetDropdown.test.ts
+++ b/src/test/components/UnseenSetDropdown.test.ts
@@ -1,0 +1,52 @@
+import UnseenSetDropdown from "@/components/UnseenSetDropdown.vue";
+import UnseenSetID from "@/service/unseen-set-id";
+import { mount } from "@vue/test-utils";
+
+const unseenSetIDs = [
+  UnseenSetID.DictionaryFr01,
+  UnseenSetID.Top999WiktionaryFr,
+];
+
+let wrapper = mount(UnseenSetDropdown);
+beforeEach(() => {
+  wrapper = mount(UnseenSetDropdown);
+});
+
+describe("unit tests", () => {
+  test("UnseenSetDropdown has the expected data", () => {
+    expect(wrapper.vm.unseenSetIDs.length).toBe(unseenSetIDs.length);
+    for (const id of unseenSetIDs) {
+      expect(wrapper.vm.unseenSetIDs).toContainEqual(id);
+    }
+  });
+  test("UnseenSetDropdown contains expected menu items", () => {
+    const menuItemLabels = unseenSetIDs.map((id) => id.menuItemLabel);
+    for (const option of wrapper.findAll("option")) {
+      expect(menuItemLabels).toContain(option.text());
+    }
+  });
+  test("'change' is emitted when dropdown menu is changed", () => {
+    wrapper.find("select").trigger("change");
+    wrapper.vm.$nextTick();
+    expect(wrapper.emitted().change).toBeTruthy();
+  });
+  test("disabled is false by default", () => {
+    expect(wrapper.props("disabled")).not.toBeTruthy();
+  });
+  test("selected element affects the UnseenSetDropdown", () => {
+    const ws = unseenSetIDs.map((id) =>
+      mount(UnseenSetDropdown, { props: { selected: id.primitive } })
+    );
+    while (ws.length > 1) {
+      expect(ws).toContain(ws[ws.length - 1]);
+      const w = ws.pop();
+      expect(ws).not.toContain(w);
+    }
+  });
+});
+
+describe("snapshot", () => {
+  test("snapshot matches with default UnseenSetDropdown", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});

--- a/src/test/components/__snapshots__/UnseenSetDropdown.test.ts.snap
+++ b/src/test/components/__snapshots__/UnseenSetDropdown.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1
+
+exports[`snapshot > snapshot matches with default UnseenSetDropdown 1`] = `
+"<div><select class=\\"p-2 bg-white border-2 disabled:bg-slate-100\\">
+    <option value=\\"2\\">🇫🇷 999 mots les plus courants</option>
+    <option value=\\"1\\">🇫🇷 liste français</option>
+  </select></div>"
+`;


### PR DESCRIPTION
I have found a limitations with the snapshot. Attributes that begin with a colon, (ex `:disabled`) are not included in `wrapper.html()` which might make it harder to snapshot components.

There might of course be a better way to do the snapshots. I haven't put much effort in it.
